### PR TITLE
add environment setter

### DIFF
--- a/source/Growthbeat/GrowthPush/GrowthPush.h
+++ b/source/Growthbeat/GrowthPush/GrowthPush.h
@@ -72,6 +72,11 @@
 - (void)clearBadge;
 
 /**
+ * Set environment
+ */
+- (void)setEnvironment:(GPEnvironment)newEnvironment;
+
+/**
  * Set Tag
  */
 - (void)setTag:(NSString *)name;

--- a/source/Growthbeat/GrowthPush/GrowthPush.m
+++ b/source/Growthbeat/GrowthPush/GrowthPush.m
@@ -233,6 +233,10 @@ static const NSTimeInterval kGPRegisterPollingInterval = 5.0f;
 
 }
 
+- (void)setEnvironment:(GPEnvironment)newEnvironment {
+    self.environment = newEnvironment;
+}
+
 - (void) setTag:(NSString *)name {
     [self setTag:name value:nil];
 }


### PR DESCRIPTION
#### environmentのsetterを追加

`requestDeviceTokenWithEnvironment`を使わず、`registerUserNotificationSettings`を行いたいため`environment`の`setter`を追加しました
(`UIUserNotificationSettings`の`categories`に値を付与したいため)

ご確認宜しくお願い致します
