### PR TITLE
deeplink失敗時もisFirstSessionをNOにする

### DIFF
--- a/source/Growthbeat/GrowthLink/GrowthLink.m
+++ b/source/Growthbeat/GrowthLink/GrowthLink.m
@@ -191,6 +191,7 @@ static NSString *const kGBPreferenceDefaultFileName = @"growthlink-preferences";
 }
 
 - (void) handleClick:(GLClick *) click{
+    isFirstSession = NO;
     if (!click || !click.pattern || !click.pattern.link) {
         [logger error:@"Failed to deeplink."];
         return;
@@ -208,7 +209,6 @@ static NSString *const kGBPreferenceDefaultFileName = @"growthlink-preferences";
     if (click.pattern.intent.id) {
         [properties setObject:click.pattern.intent.id forKey:@"intentId"];
     }
-    isFirstSession = NO;
     
     if (click.pattern.intent) {
         dispatch_async(dispatch_get_main_queue(), ^{


### PR DESCRIPTION
初回起動時のdeeplink失敗が後のdeeplinkに影響を及ぼす可能性があったので修正
