### PR TITLE
Remove AddSupport

### DIFF
--- a/source/Growthbeat/GrowthbeatCore/GBDeviceUtils.m
+++ b/source/Growthbeat/GrowthbeatCore/GBDeviceUtils.m
@@ -9,11 +9,14 @@
 #import "GBDeviceUtils.h"
 #import <UIKit/UIKit.h>
 #import <SystemConfiguration/SystemConfiguration.h>
-#import <AdSupport/AdSupport.h>
 #import <mach/mach.h>
 #import <netinet/in.h>
 #include <sys/types.h>
 #include <sys/sysctl.h>
+
+#if !BEAT_NO_IDFA
+#import <AdSupport/AdSupport.h>
+#endif
 
 @implementation GBDeviceUtils
 
@@ -171,23 +174,30 @@
 }
 
 + (NSString *) getAdvertisingId {
-
+    
+#if BEAT_NO_IDFA
+    return nil;
+#else
     ASIdentifierManager *identifierManager = [ASIdentifierManager sharedManager];
-
+    
     if (![identifierManager isAdvertisingTrackingEnabled]) {
         return nil;
     }
-
     return identifierManager.advertisingIdentifier.UUIDString;
-
+#endif
+    
 }
 
 + (BOOL) getTrackingEnabled {
-
+    
+#if BEAT_NO_IDFA
+    return nil;
+#else
     ASIdentifierManager *identifierManager = [ASIdentifierManager sharedManager];
-
+    
     return [identifierManager isAdvertisingTrackingEnabled];
-
+#endif
+    
 }
 
 @end


### PR DESCRIPTION
Add the compiler flag BEAT_NO_IDFA

In the Project Navigator select your project. Make sure your target is selected in the top left corner of the right hand window.

Select the Build Settings tab and search for Other C Flags in the search field below.

Double click on the right side of the Other C Flags line to change its value

Press on the + button at the bottom of the overlay and paste the following text into the selected line:

```
 -DBEAT_NO_IDFA
```

Ref:
- [Remove IDFA support](https://github.com/adjust/ios_sdk/blob/1a2c3f8c67d5b8e74bca9c5380f30419e6aee2a0/doc/idfa.md)
- [ios_sdk/Adjust/ADJAdditions/UIDevice+ADJAdditions.m](https://github.com/adjust/ios_sdk/blob/413ca434aeed18bf52b0a632f1fa4a623f1d3c86/Adjust/ADJAdditions/UIDevice%2BADJAdditions.m)
