### PR TITLE
FIX: no rule to process file

### DIFF
--- a/Growthbeat.podspec
+++ b/Growthbeat.podspec
@@ -13,9 +13,13 @@ Pod::Spec.new do |s|
   s.source = {:git => "https://github.com/growthbeat/growthbeat-ios.git", :tag => "#{s.version}"}
   s.source_files = [
       "Growthbeat/**/*.h",
-      "Growthbeat/**/*.m",
-      "Growthbeat/**/*.xcprivacy" 
+      "Growthbeat/**/*.m"
   ]
+  s.resource_bundles = {
+    "Growthbeat" => [
+      "Growthbeat/**/*.xcprivacy"
+    ]
+  }
   s.frameworks = [
       "SystemConfiguration",
       "UIKit",

--- a/Growthbeat.podspec
+++ b/Growthbeat.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name = "Growthbeat"
-  s.version = "2.1.0"
+  s.version = "2.1.1"
   s.summary = "Growthbeat SDK for iOS"
   s.description = <<-DESC
   Growthbeat is growth hack platform for smart devices.

--- a/GrowthbeatSample.xcodeproj/project.pbxproj
+++ b/GrowthbeatSample.xcodeproj/project.pbxproj
@@ -311,7 +311,7 @@
 				CODE_SIGN_ENTITLEMENTS = GrowthbeatSample/GrowthbeatSample.entitlements;
 				CODE_SIGN_IDENTITY = "iPhone Developer: Yuto Mukoyama (S4DY4ST4FA)";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 2.0.7;
+				CURRENT_PROJECT_VERSION = 2.1.1;
 				DEVELOPMENT_TEAM = KXJAKTLCBX;
 				FRAMEWORK_SEARCH_PATHS = "$(inherited)";
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
@@ -322,7 +322,7 @@
 					"$(inherited)",
 					"$(PROJECT_DIR)/build/Debug-iphoneos",
 				);
-				MARKETING_VERSION = 2.0.7;
+				MARKETING_VERSION = 2.1.1;
 				OTHER_CFLAGS = "";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE = "";
@@ -338,7 +338,7 @@
 				CODE_SIGN_ENTITLEMENTS = GrowthbeatSample/GrowthbeatSample.entitlements;
 				CODE_SIGN_IDENTITY = "iPhone Distribution: SIROK, Inc. (KXJAKTLCBX)";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 2.0.7;
+				CURRENT_PROJECT_VERSION = 2.1.1;
 				DEVELOPMENT_TEAM = KXJAKTLCBX;
 				FRAMEWORK_SEARCH_PATHS = "$(inherited)";
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
@@ -348,7 +348,7 @@
 					"$(inherited)",
 					"$(PROJECT_DIR)/build/Debug-iphoneos",
 				);
-				MARKETING_VERSION = 2.0.7;
+				MARKETING_VERSION = 2.1.1;
 				OTHER_CFLAGS = "";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE = "";


### PR DESCRIPTION
```
no rule to process file '/path/to/PrivacyInfo.xcprivacy' of type 'text.xml' for architecture 'arm64' (in target 'Growthbeat' from project 'Pods')
```